### PR TITLE
Board of Directors Charter

### DIFF
--- a/Essential/Board of Advisors.md
+++ b/Essential/Board of Advisors.md
@@ -20,6 +20,7 @@ A special proposal that is related to Corporation Legislation, proposed by the D
 **REQUEST:**
 A Request is a formal expression of opinion from one group or individual to another group or individual for a reason.
 > Example: A formal request from SC to ID to begin to enforce public test logging.
+
 > Example: A formal request from the Regulations Department to promote user "JohnDoe"'s Class-E to permanent.
 
 ### Rules

--- a/Essential/Board of Advisors.md
+++ b/Essential/Board of Advisors.md
@@ -1,30 +1,37 @@
 ## The Board of Advisors
 > This law, upon admitance into the general Nova Corporation Base Law, commissions this document as the primary charter of the Board of Advisors.
 
-The Board of Advisors is a collection of Departmental Representatives charged with introduction, discussion, and authorization of laws and policies for the entire Nova Corporation.
+The Board of Advisors is a collection of Departmental Representatives charged with introduction, discussion, and authorization of laws and policies for the entire Nova Corporation. Members of the Class-X Overwatch are inheritly not a part of the Board of Advisors, as the Board of Advisors reports to them directly.
 
 ### Membership
 * Representatives must be a member of the Department they intend to represent.
-* Representatives must maintain good standing within their Department and the Corporation.
+* Representatives must have good standing within their Department and the Corporation.
 * Amount of Representatives are controlled by the Class-X of the Department they are representing.
 * Personnel ranking Class-O and above who are not within a department are granted the ability to become a Representative, as an Independent or "NCM Representative".
 
 ### Procedure
+> Example Format
+
 **PROPOSAL:**
 A Proposal is a formal act of legality for the Class-X Overwatch to follow.
-> Example: Establishment of the Class-X Transparency Act.
+> Establishment of the Class-X Transparency Act.
 
 **LEGISLATION:**
-A special proposal that is related to Corporation Legislation, proposed by the Department Legislation, for changes to the primary legal document of the Corporation.
-> Example: Confirmation Vote for AoS LAW0025 "UH-60 and CV-22 Vehicles Regulations".
+A special proposal that is related to Corporation Legislation, proposed by the Legislative Branch of the Regulations Department, for changes to the primary legal document of the Corporation.
+> Confirmation Vote for AoS LAW0025 "UH-60 and CV-22 Vehicles Regulations".
 
 **REQUEST:**
 A Request is a formal expression of opinion from one group or individual to another group or individual for a reason.
-> Example: A formal request from SC to ID to begin to enforce public test logging.
+> A formal request from SC to ID to begin to enforce public test logging.
 
-> Example: A formal request from the Regulations Department to upgrade user "JohnDoe"'s Class-E to permanent.
+> A formal request from the Regulations Department to upgrade user "JohnDoe"'s Class-E to permanent.
+
+**RANK CHANGE:**
+A Special Request created as a referendum for the rank status of someone within the Corporation.
+> A formal request for the processing of the promotion for "JaneDoe" to Class-A. 
 
 ### Rules
 * Representatives must show respect from one to another.
+* Representatives must maintain good standing within their Department and the Corporation, removal from their department they are representing means an automatic removal from the Board of Advisors, unless through special case allowed by the Class-X Overwatch.
 * Representatives must maintain professionalism within proposals.
 * Representatives must issue a show an opinion (Aye or Nay) on a minimum of 1 out of every 2 global votes, else risking dismissal from the Board of Advisors.

--- a/Essential/Board of Advisors.md
+++ b/Essential/Board of Advisors.md
@@ -1,0 +1,27 @@
+## The Board of Advisors
+> This law, upon admitance into the general Nova Corporation Base Law, commissions this document as the primary charter of the Board of Advisors.
+
+The Board of Advisors is a collection of Departmental Representatives charged with introduction, discussion, and authorization of laws and policies for the entire Nova Corporation.
+
+### Membership
+* Representatives must be a member of the Department they intend to represent.
+* Representatives must maintain good standing within their Department and the Corporation.
+* Amount of Representatives are TBD.
+
+### Procedure
+**PROPOSAL:**
+A Proposal is a formal act of legality for the Class-X Overwatch to follow.
+> Example: Establishment of the Class-X Transparency Act.
+
+**LEGISLATION:**
+A special proposal that is related to Corporation Legislation, proposed by the Department Legislation, for changes to the primary legal document of the Corporation.
+> Example: Confirmation Vote for AoS LAW0025 "UH-60 and CV-22 Vehicles Regulations".
+
+**REQUEST:**
+A Request is a formal expression of opinion from one group or individual to another group or individual for a reason.
+> Example: A formal request from SC to ID to begin to enforce public test logging.
+> Example: A formal request from the Regulations Department to promote user "JohnDoe"'s Class-E to permanent.
+
+### Rules
+* Departmental Representatives must show respect from one to another.
+* Departmental Representatives must maintain professionalism within proposals.

--- a/Essential/Board of Advisors.md
+++ b/Essential/Board of Advisors.md
@@ -6,7 +6,8 @@ The Board of Advisors is a collection of Departmental Representatives charged wi
 ### Membership
 * Representatives must be a member of the Department they intend to represent.
 * Representatives must maintain good standing within their Department and the Corporation.
-* Amount of Representatives are TBD.
+* Amount of Representatives are controlled by the Class-X of the Department they are representing.
+* Personnel ranking Class-O and above who are not within a department are granted the ability to become a Representative, as an Independent or "NCM Representative".
 
 ### Procedure
 **PROPOSAL:**
@@ -21,8 +22,9 @@ A special proposal that is related to Corporation Legislation, proposed by the D
 A Request is a formal expression of opinion from one group or individual to another group or individual for a reason.
 > Example: A formal request from SC to ID to begin to enforce public test logging.
 
-> Example: A formal request from the Regulations Department to promote user "JohnDoe"'s Class-E to permanent.
+> Example: A formal request from the Regulations Department to upgrade user "JohnDoe"'s Class-E to permanent.
 
 ### Rules
-* Departmental Representatives must show respect from one to another.
-* Departmental Representatives must maintain professionalism within proposals.
+* Representatives must show respect from one to another.
+* Representatives must maintain professionalism within proposals.
+* Representatives must issue a show an opinion (Aye or Nay) on a minimum of 1 out of every 2 global votes, else risking dismissal from the Board of Advisors.


### PR DESCRIPTION
With the creation of the "Nova Corporation Laws" discord server, it has become clear that a defining document needed to be set in place. This seeks to establish a sort of official "charter" for the Laws discord server. As with this request, I also request that the name of the server be changed to "The Board of Advisors" or another name for less confusion when referring to it.